### PR TITLE
Router compressor on chip

### DIFF
--- a/spynnaker_external_devices_plugin/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
+++ b/spynnaker_external_devices_plugin/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
@@ -36,6 +36,7 @@ from spinn_front_end_common.interface.simulation import simulation_utilities
 
 # general imports
 import logging
+from spinnman.model.enums.executable_start_type import ExecutableStartType
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,10 @@ class MunichMotorDevice(
     @overrides(AbstractHasAssociatedBinary.get_binary_file_name)
     def get_binary_file_name(self):
         return "robot_motor_control.aplx"
+
+    @overrides(AbstractHasAssociatedBinary.get_binary_start_mode_enum)
+    def get_binary_start_mode_enum(self):
+        return ExecutableStartType.USES_SIMULATION_INTERFACE
 
     def reserve_memory_regions(self, spec):
         """


### PR DESCRIPTION
added on chip router compressor of mundy's into the main tool chain.

It includes fixes to the c code so that:

1. it works using sdram all the way though,
2. supports different functionality in how much and when to do compression.
3. No more RTE's but using error codes via user 0 register
includes python changes:

1. which pushes more control logic into SpiNNMan from FEC.
2. fixes pacman executor to handle optimal algorithms properly.
3. supports coresubsets and core subset infos which are the info objects from the cores. instead of doing some translation between them
4. supports getting the first none_monitor core from the chip.
5. adds new interface for types of starting functionality for better support

the python polls the cores till they finish, as its a in deterministic timeframe
There are a few integration tests, including a speed test between the python and c.

depends upon these branches;
PACMAN, FrontEndCommon, SpiNNMachine, SpinnMan, GFE, SPY

 done by alan
 needs reviewing from rowley.